### PR TITLE
Add staging buffer before actual vertex buffer.

### DIFF
--- a/src/vulkan_engine.h
+++ b/src/vulkan_engine.h
@@ -67,6 +67,10 @@ private:
   void CreateFramebuffers();
 
   // Vertex Buffers
+  void CreateBuffer(VkDeviceSize size, VkBufferUsageFlags usage,
+                    VkMemoryPropertyFlags properties, VkBuffer &buffer,
+                    VkDeviceMemory &buffer_memory);
+  void CopyBuffer(VkBuffer src_buffer, VkBuffer dst_buffer, VkDeviceSize size);
   void CreateVertexBuffer();
   uint32_t FindMemoryType(uint32_t type_filter,
                           VkMemoryPropertyFlags properties);


### PR DESCRIPTION
This is done so that memory of type VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT can be used and accessed by the GPU. This memory is not accessible from the CPU. That's why a staging buffer, that the CPU can access, is created. The data will be moved from staging buffer to the actual vertex buffer.