### PR TITLE
Fix Windows compilation and Wayland behaviour.

### DIFF
--- a/src/vulkan_engine.h
+++ b/src/vulkan_engine.h
@@ -134,7 +134,6 @@ private:
   std::vector<VkSemaphore> image_available_semaphores_;
   std::vector<VkSemaphore> render_finished_semaphores_;
   std::vector<VkFence> in_flight_fences_;
-  bool framebuffer_resized_ = false;
 
   VkDescriptorPool imgui_descriptor_pool_;
 


### PR DESCRIPTION
Remove the unnecessary header unistd.h which caused Windows compilation error.
On Wayland, during SDL window resize event, the swap chain needs to be recreated instantly. The code, until now, was hanging on Wayland, on the SDL_PollEvent call.