### PR TITLE
Add depth buffer support.

### DIFF
--- a/src/shaders/shader.vert
+++ b/src/shaders/shader.vert
@@ -6,13 +6,13 @@ layout(binding = 0) uniform UniformBufferObject {
     mat4 projection;
 } ubo;
 
-layout(location = 0) in vec2 inPosition;
+layout(location = 0) in vec3 inPosition;
 layout(location = 1) in vec3 inColor;
 
 layout(location = 0) out vec3 fragColor;
 
 void main() {
-    gl_Position = ubo.projection * ubo.view * ubo.model * vec4(inPosition, 0.0, 1.0);
+    gl_Position = ubo.projection * ubo.view * ubo.model * vec4(inPosition, 1.0);
     fragColor = inColor;
 }
 

--- a/src/vulkan_engine.h
+++ b/src/vulkan_engine.h
@@ -81,11 +81,29 @@ private:
   void CreateDescriptorPool();
   void CreateDescriptorSets();
 
+  // Depth buffer
+  void CreateDepthResources();
+  std::optional<VkFormat>
+  FindSupportedFormat(const std::vector<VkFormat> &candidates,
+                      VkImageTiling tiling, VkFormatFeatureFlags features);
+  std::optional<VkFormat> FindDepthFormat();
+  std::optional<VkImageView> CreateImageView(VkImage image, VkFormat format,
+                                             VkImageAspectFlags aspect_flags);
+  void CreateImage(uint32_t width, uint32_t height, VkFormat format,
+                   VkImageTiling tiling, VkImageUsageFlags usage,
+                   VkMemoryPropertyFlags properties, VkImage &image,
+                   VkDeviceMemory &image_memory);
+  void TransitionImageLayout(VkImage image, VkFormat format,
+                             VkImageLayout old_layout,
+                             VkImageLayout new_layout);
+
   // Commands
   void CreateCommandPool();
   void CreateCommandBuffer();
   void RecordCommandBuffer(VkCommandBuffer command_buffer,
                            uint32_t image_index);
+  VkCommandBuffer BeginSingleTimeCommands();
+  void EndSingleTimeCommands(VkCommandBuffer command_buffer);
 
   // Drawing
   void CreateSyncObjects();
@@ -130,6 +148,9 @@ private:
   std::vector<void *> uniform_buffers_mapped_;
   VkDescriptorPool descriptor_pool_;
   std::vector<VkDescriptorSet> descriptor_sets_;
+  VkImage depth_image_;
+  VkDeviceMemory depth_image_memory_;
+  VkImageView depth_image_view_;
   std::vector<VkCommandBuffer> command_buffers_;
   std::vector<VkSemaphore> image_available_semaphores_;
   std::vector<VkSemaphore> render_finished_semaphores_;


### PR DESCRIPTION
* Switch Vertex struct for vec3 positions.
* Extend render pass with depth attachment.
* Create depth related resources.
* Enable depth test.
* Update framebuffers to include depth image view.
* Clear both color and depth attachments at render start.